### PR TITLE
Fix torch hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ You can choose to download only the weights of the pretrained backbone used for 
 The pretrained models are available on PyTorch Hub.
 ```python
 import torch
-deits16 = torch.hub.load('facebookresearch/dino', 'dino_deits16')
-deits8 = torch.hub.load('facebookresearch/dino', 'dino_deits8')
-vitb16 = torch.hub.load('facebookresearch/dino', 'dino_vitb16')
-vitb8 = torch.hub.load('facebookresearch/dino', 'dino_vitb8')
-resnet50 = torch.hub.load('facebookresearch/dino', 'dino_resnet50')
+deits16 = torch.hub.load('facebookresearch/dino:main', 'dino_deits16')
+deits8 = torch.hub.load('facebookresearch/dino:main', 'dino_deits8')
+vitb16 = torch.hub.load('facebookresearch/dino:main', 'dino_vitb16')
+vitb8 = torch.hub.load('facebookresearch/dino:main', 'dino_vitb8')
+resnet50 = torch.hub.load('facebookresearch/dino:main', 'dino_resnet50')
 ```
 
 ## Training


### PR DESCRIPTION
Closes https://github.com/facebookresearch/dino/issues/5

> The default branch for torch hub load is master, but facebookresearch/dino uses main, so you need to specify the branch you are downloading