### PR TITLE
custom intensity normalisation of incoming images

### DIFF
--- a/eval_knn.py
+++ b/eval_knn.py
@@ -31,7 +31,7 @@ def extract_feature_pipeline(args):
         pth_transforms.Resize(256, interpolation=3),
         pth_transforms.CenterCrop(224),
         pth_transforms.ToTensor(),
-        pth_transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+        pth_transforms.Normalize(args.mean, args.std),
     ])
     dataset_train = ReturnIndexDataset(os.path.join(args.data_path, "train"), transform=transform)
     dataset_val = ReturnIndexDataset(os.path.join(args.data_path, "val"), transform=transform)
@@ -198,6 +198,21 @@ if __name__ == '__main__':
         distributed training; see https://pytorch.org/docs/stable/distributed.html""")
     parser.add_argument("--local_rank", default=0, type=int, help="Please ignore and do not set this argument.")
     parser.add_argument('--data_path', default='/path/to/imagenet/', type=str)
+
+    parser.add_argument('--mean',
+                        type=float,
+                        nargs='+',
+                        default=[0.485, 0.456, 0.406],
+                        help="""Override mean pixel value of dataset for
+                        gaussian normalization during preprocessing,
+                        expressed as ratio to max of torch.dtype""")
+    parser.add_argument('--std',
+                        type=float,
+                        nargs='+',
+                        default=[0.229, 0.224, 0.225],
+                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        )
+
     args = parser.parse_args()
 
     utils.init_distributed_mode(args)

--- a/eval_knn.py
+++ b/eval_knn.py
@@ -210,7 +210,7 @@ if __name__ == '__main__':
                         type=float,
                         nargs='+',
                         default=[0.229, 0.224, 0.225],
-                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        help='Override standard deviation of pixel intensities for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
                         )
 
     args = parser.parse_args()

--- a/eval_linear.py
+++ b/eval_linear.py
@@ -38,13 +38,13 @@ def eval_linear(args):
         pth_transforms.RandomResizedCrop(224),
         pth_transforms.RandomHorizontalFlip(),
         pth_transforms.ToTensor(),
-        pth_transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+        pth_transforms.Normalize(args.mean, args.std),
     ])
     val_transform = pth_transforms.Compose([
         pth_transforms.Resize(256, interpolation=3),
         pth_transforms.CenterCrop(224),
         pth_transforms.ToTensor(),
-        pth_transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+        pth_transforms.Normalize(args.mean, args.std),
     ])
     dataset_train = datasets.ImageFolder(os.path.join(args.data_path, "train"), transform=train_transform)
     dataset_val = datasets.ImageFolder(os.path.join(args.data_path, "val"), transform=val_transform)
@@ -248,5 +248,21 @@ if __name__ == '__main__':
     parser.add_argument('--val_freq', default=1, type=int, help="Epoch frequency for validation.")
     parser.add_argument('--output_dir', default=".", help='Path to save logs and checkpoints')
     parser.add_argument('--num_labels', default=1000, type=int, help='Number of labels for linear classifier')
+
+    parser.add_argument('--mean',
+                        type=float,
+                        nargs='+',
+                        default=[0.485, 0.456, 0.406],
+                        help="""Override mean pixel value of dataset for
+                        gaussian normalization during preprocessing,
+                        expressed as ratio to max of torch.dtype""")
+    parser.add_argument('--std',
+                        type=float,
+                        nargs='+',
+                        default=[0.229, 0.224, 0.225],
+                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        )
+
+
     args = parser.parse_args()
     eval_linear(args)

--- a/eval_linear.py
+++ b/eval_linear.py
@@ -260,7 +260,7 @@ if __name__ == '__main__':
                         type=float,
                         nargs='+',
                         default=[0.229, 0.224, 0.225],
-                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        help='Override standard deviation of pixel intensities for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
                         )
 
 

--- a/main_dino.py
+++ b/main_dino.py
@@ -42,9 +42,9 @@ def get_args_parser():
     parser = argparse.ArgumentParser('DINO', add_help=False)
 
     # preprocessing
-    parser.add_argument('--mean', type=float, nargs='+', default=[0.485, 0.456, 0.406], #metavar='MEAN',
+    parser.add_argument('--mean', type=float, nargs='+', default=[0.485, 0.456, 0.406],
                         help='Override mean pixel value of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
-    parser.add_argument('--std', type=float, nargs='+', default=[0.229, 0.224, 0.225], #metavar='STD',
+    parser.add_argument('--std', type=float, nargs='+', default=[0.229, 0.224, 0.225],
                         help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
 
     # Model parameters

--- a/main_dino.py
+++ b/main_dino.py
@@ -45,7 +45,7 @@ def get_args_parser():
     parser.add_argument('--mean', type=float, nargs='+', default=[0.485, 0.456, 0.406],
                         help='Override mean pixel value of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
     parser.add_argument('--std', type=float, nargs='+', default=[0.229, 0.224, 0.225],
-                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
+                        help='Override standard deviation of pixel intensities for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
 
     # Model parameters
     parser.add_argument('--arch', default='vit_small', type=str,

--- a/video_generation.py
+++ b/video_generation.py
@@ -161,7 +161,7 @@ class VideoGenerator:
                         pth_transforms.ToTensor(),
                         pth_transforms.Resize(self.args.resize),
                         pth_transforms.Normalize(
-                            (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)
+                            self.args.mean, self.args.std
                         ),
                     ]
                 )
@@ -170,7 +170,7 @@ class VideoGenerator:
                     [
                         pth_transforms.ToTensor(),
                         pth_transforms.Normalize(
-                            (0.485, 0.456, 0.406), (0.229, 0.224, 0.225)
+                            self.args.mean, self.args.std
                         ),
                     ]
                 )
@@ -364,6 +364,23 @@ def parse_args():
         type=str,
         choices=["mp4", "avi"],
         help="Format of generated video (mp4 or avi).",
+    )
+
+    parser.add_argument(
+        '--mean',
+        type=float,
+        nargs='+',
+        default=[0.485, 0.456, 0.406],
+        help="""Override mean pixel value of dataset for
+        gaussian normalization during preprocessing,
+        expressed as ratio to max of torch.dtype""")
+
+    parser.add_argument(
+        '--std',
+        type=float,
+        nargs='+',
+        default=[0.229, 0.224, 0.225],
+        help='Override standard deviation of pixel values for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
     )
 
     return parser.parse_args()

--- a/visualize_attention.py
+++ b/visualize_attention.py
@@ -98,6 +98,7 @@ def display_instances(image, mask, fname="test", figsize=(5, 5), blur=False, con
 if __name__ == '__main__':
 
     parser = argparse.ArgumentParser('Visualize Self-Attention maps')
+
     parser.add_argument('--arch', default='vit_small', type=str,
         choices=['vit_tiny', 'vit_small', 'vit_base'], help='Architecture (support only ViT atm).')
     parser.add_argument('--patch_size', default=8, type=int, help='Patch resolution of the model.')
@@ -107,13 +108,22 @@ if __name__ == '__main__':
         help='Key to use in the checkpoint (example: "teacher")')
     parser.add_argument("--image_path", default=None, type=str, help="Path of the image to load.")
     parser.add_argument('--output_dir', default='.', help='Path where to save visualizations.')
-    parser.add_argument("--threshold", type=float, default=0.6, help="""We visualize masks
-        obtained by thresholding the self-attention maps to keep xx% of the mass.""")
+    parser.add_argument("--threshold", type=float, default=0.6,
+                        help='We visualize masks obtained by thresholding the self-attention maps to keep <THRESHOLD>%% of the mass.')
 
-    parser.add_argument('--mean', type=float, nargs='+', default=[0.485, 0.456, 0.406], #metavar='MEAN',
-                        help='Override mean pixel value of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
-    parser.add_argument('--std', type=float, nargs='+', default=[0.229, 0.224, 0.225], #metavar='STD',
-                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
+    parser.add_argument('--mean',
+                        type=float,
+                        nargs='+',
+                        default=[0.485, 0.456, 0.406],
+                        help="""Override mean pixel value of dataset for
+                        gaussian normalization during preprocessing,
+                        expressed as ratio to max of torch.dtype""")
+    parser.add_argument('--std',
+                        type=float,
+                        nargs='+',
+                        default=[0.229, 0.224, 0.225],
+                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        )
 
     args = parser.parse_args()
 
@@ -122,8 +132,10 @@ if __name__ == '__main__':
     model = vits.__dict__[args.arch](patch_size=args.patch_size, num_classes=0)
     for p in model.parameters():
         p.requires_grad = False
+
     model.eval()
     model.to(device)
+
     if os.path.isfile(args.pretrained_weights):
         state_dict = torch.load(args.pretrained_weights, map_location="cpu")
         if args.checkpoint_key is not None and args.checkpoint_key in state_dict:

--- a/visualize_attention.py
+++ b/visualize_attention.py
@@ -108,7 +108,7 @@ if __name__ == '__main__':
         help='Key to use in the checkpoint (example: "teacher")')
     parser.add_argument("--image_path", default=None, type=str, help="Path of the image to load.")
     parser.add_argument('--output_dir', default='.', help='Path where to save visualizations.')
-    parser.add_argument("--threshold", type=float, default=0.6,
+    parser.add_argument("--threshold", type=float, default=None,
                         help='We visualize masks obtained by thresholding the self-attention maps to keep <THRESHOLD>%% of the mass.')
 
     parser.add_argument('--mean',

--- a/visualize_attention.py
+++ b/visualize_attention.py
@@ -96,6 +96,7 @@ def display_instances(image, mask, fname="test", figsize=(5, 5), blur=False, con
 
 
 if __name__ == '__main__':
+
     parser = argparse.ArgumentParser('Visualize Self-Attention maps')
     parser.add_argument('--arch', default='vit_small', type=str,
         choices=['vit_tiny', 'vit_small', 'vit_base'], help='Architecture (support only ViT atm).')
@@ -108,6 +109,12 @@ if __name__ == '__main__':
     parser.add_argument('--output_dir', default='.', help='Path where to save visualizations.')
     parser.add_argument("--threshold", type=float, default=0.6, help="""We visualize masks
         obtained by thresholding the self-attention maps to keep xx% of the mass.""")
+
+    parser.add_argument('--mean', type=float, nargs='+', default=[0.485, 0.456, 0.406], #metavar='MEAN',
+                        help='Override mean pixel value of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
+    parser.add_argument('--std', type=float, nargs='+', default=[0.229, 0.224, 0.225], #metavar='STD',
+                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio of max(torch.dtype)')
+
     args = parser.parse_args()
 
     device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
@@ -161,9 +168,13 @@ if __name__ == '__main__':
     else:
         print(f"Provided image path {args.image_path} is non valid.")
         sys.exit(1)
+
+    mean_normalisation = args.mean if len(args.mean) == 3 else 3*(args.mean[0],)
+    std_normalisation = args.std if len(args.std) == 3 else 3*(args.std[0],)
+
     transform = pth_transforms.Compose([
         pth_transforms.ToTensor(),
-        pth_transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225)),
+        pth_transforms.Normalize(mean_normalisation, std_normalisation),
     ])
     img = transform(img)
 

--- a/visualize_attention.py
+++ b/visualize_attention.py
@@ -122,7 +122,7 @@ if __name__ == '__main__':
                         type=float,
                         nargs='+',
                         default=[0.229, 0.224, 0.225],
-                        help='Override std deviation of dataset for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
+                        help='Override standard deviation of pixel intensities for gaussian normalization during preprocessing, expressed as ratio to max of torch.dtype'
                         )
 
     args = parser.parse_args()


### PR DESCRIPTION
This PR adds mean and standard deviation for image normalisation customizable on the command line. This allows users to ingest non-imagenet images as they can run DINO as:

```
$ python main_dino.py --mean 0.440 --std 0.25 ...
# would internally use torchvision.Normalize([0.440,0.440,0.440],[0.25,0.25,0.25])
```
or 
```
$ python main_dino.py --mean 0.440 0.441 0.442 --std 0.250 0.251 0.252 ...
# would internally use torchvision.Normalize([0.440,0.441,0.442],[0.250,0.251,0.252])
```
The first is handy for greyscale images, the latter more appropriate for RGB images.

NB. I only tested this with `main_dino.py` and `visualize_attention.py` yet.