### PR TITLE
Apply learning rate scaling to min_lr

### DIFF
--- a/main_dino.py
+++ b/main_dino.py
@@ -227,9 +227,11 @@ def train_dino(args):
         fp16_scaler = torch.cuda.amp.GradScaler()
 
     # ============ init schedulers ... ============
+    # linear scaling rule
+    lr_scale = (args.batch_size_per_gpu * utils.get_world_size()) / 256.
     lr_schedule = utils.cosine_scheduler(
-        args.lr * (args.batch_size_per_gpu * utils.get_world_size()) / 256.,  # linear scaling rule
-        args.min_lr,
+        args.lr * lr_scale,  
+        args.min_lr * lr_scale,
         args.epochs, len(data_loader),
         warmup_epochs=args.warmup_epochs,
     )


### PR DESCRIPTION
I wanted to clarify how the linear learning rate scaling should be handled; this is sort of an edge case, but I think in order to obtain the correct learning rate when continuing the training from checkpoints on a different GPU count/with a different batch size, it would be required to also scale the `min_lr`?

Here's a visualization of the difference between the current & the proposed implementation (for a few example parameters, `epochs = 42, niter_per_ep = 100, lr = 1e-4, lr_scale = 5`):

![image](https://user-images.githubusercontent.com/727984/120533784-66854500-c3e1-11eb-801a-215066b4d79b.png)

It would be great to confirm which implementation produces the desired behavior; if it is the current version, I would propose to add a short inline comment to clarify.

---
To repro the plot and play around with other values, here's a small script:

```python
import matplotlib.pyplot as plt
import numpy as np

def cosine_scheduler(base_value, final_value, epochs, niter_per_ep, warmup_epochs=0, start_warmup_value=0):
    warmup_schedule = np.array([])
    warmup_iters = warmup_epochs * niter_per_ep
    if warmup_epochs > 0:
        warmup_schedule = np.linspace(start_warmup_value, base_value, warmup_iters)

    iters = np.arange(epochs * niter_per_ep - warmup_iters)
    schedule = final_value + 0.5 * (base_value - final_value) * (1 + np.cos(np.pi * iters / len(iters)))

    schedule = np.concatenate((warmup_schedule, schedule))
    assert len(schedule) == epochs * niter_per_ep
    return schedule

def plot():
    lr_scale = 5
    lr = 1e-4
    min_lr = 1e-6
    kwargs = dict(
        epochs = 42,
        niter_per_ep = 100
    )

    schedule_current = cosine_scheduler(
        lr * lr_scale,
        min_lr,
        **kwargs
    )

    schedule_fixed = cosine_scheduler(
        lr * lr_scale,
        min_lr * lr_scale,
        **kwargs
    )

    plt.figure(figsize=(2,2), dpi = 160)
    plt.plot(schedule_current, label = "current")
    plt.plot(schedule_fixed, label = "proposed")
    plt.yscale("log")
    plt.legend()
    plt.show()
    
plot()
```