### PR TITLE
 Replace the looping with gather ops

### DIFF
--- a/visualize_attention.py
+++ b/visualize_attention.py
@@ -190,8 +190,7 @@ if __name__ == '__main__':
         cumval = torch.cumsum(val, dim=1)
         th_attn = cumval > (1 - args.threshold)
         idx2 = torch.argsort(idx)
-        for head in range(nh):
-            th_attn[head] = th_attn[head][idx2[head]]
+        th_attn = torch.gather(th_attn, 1, idx2)
         th_attn = th_attn.reshape(nh, w_featmap, h_featmap).float()
         # interpolate
         th_attn = nn.functional.interpolate(th_attn.unsqueeze(0), scale_factor=args.patch_size, mode="nearest")[0].cpu().numpy()


### PR DESCRIPTION
The for-loop can be replaced with torch.gather to speed up the operation.