### PR TITLE
Add W&B Logging

### DIFF
--- a/main_dino.py
+++ b/main_dino.py
@@ -134,8 +134,6 @@ def get_args_parser():
 
 
 def train_dino(args):
-    if args.use_wandb:
-        wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
     utils.init_distributed_mode(args)
     utils.fix_random_seeds(args.seed)
     print("git:\n  {}\n".format(utils.get_sha()))
@@ -302,14 +300,12 @@ def train_dino(args):
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print('Training time {}'.format(total_time_str))
-    if args.use_wandb:
-        wandb.finish()
 
 
 def train_one_epoch(student, teacher, teacher_without_ddp, dino_loss, data_loader,
                     optimizer, lr_schedule, wd_schedule, momentum_schedule,epoch,
                     fp16_scaler, args):
-    metric_logger = utils.MetricLogger(delimiter="  ", use_wandb = args.use_wandb)
+    metric_logger = utils.MetricLogger(args, delimiter=" ")
     header = 'Epoch: [{}/{}]'.format(epoch, args.epochs)
     for it, (images, _) in enumerate(metric_logger.log_every(data_loader, 10, header)):
         # update weight decay and learning rate according to their schedule

--- a/main_dino.py
+++ b/main_dino.py
@@ -29,7 +29,6 @@ import torch.backends.cudnn as cudnn
 import torch.nn.functional as F
 from torchvision import datasets, transforms
 from torchvision import models as torchvision_models
-import wandb
 
 import utils
 import vision_transformer as vits

--- a/main_dino.py
+++ b/main_dino.py
@@ -128,10 +128,14 @@ def get_args_parser():
         distributed training; see https://pytorch.org/docs/stable/distributed.html""")
     parser.add_argument("--local_rank", default=0, type=int, help="Please ignore and do not set this argument.")
     parser.add_argument("--use_wandb", default=True, type = bool, help = "Whether to use W&B for metric logging")
+    parser.add_argument("--wandb_project", default="dino", type=str, help="Name of the W&B Project")
+    parser.add_argument("--wandb_entity", default=None, type=str, help="entity to use for W&B logging")
     return parser
 
 
 def train_dino(args):
+    if args.use_wandb:
+        wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
     utils.init_distributed_mode(args)
     utils.fix_random_seeds(args.seed)
     print("git:\n  {}\n".format(utils.get_sha()))
@@ -298,6 +302,8 @@ def train_dino(args):
     total_time = time.time() - start_time
     total_time_str = str(datetime.timedelta(seconds=int(total_time)))
     print('Training time {}'.format(total_time_str))
+    if args.use_wandb:
+        wandb.finish()
 
 
 def train_one_epoch(student, teacher, teacher_without_ddp, dino_loss, data_loader,
@@ -470,6 +476,4 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('DINO', parents=[get_args_parser()])
     args = parser.parse_args()
     Path(args.output_dir).mkdir(parents=True, exist_ok=True)
-    wandb.init(project="dino-integration", entity="sauravmaheshkar", config=args)
     train_dino(args)
-    wandb.finish()

--- a/utils.py
+++ b/utils.py
@@ -28,6 +28,7 @@ from collections import defaultdict, deque
 
 import numpy as np
 import torch
+import wandb
 from torch import nn
 import torch.distributed as dist
 from PIL import ImageFilter, ImageOps
@@ -311,9 +312,10 @@ def reduce_dict(input_dict, average=True):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t"):
+    def __init__(self, delimiter="\t", use_wandb = True):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
+        self.use_wandb = use_wandb
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -321,6 +323,7 @@ class MetricLogger(object):
                 v = v.item()
             assert isinstance(v, (float, int))
             self.meters[k].update(v)
+        wandb.log(self.meters)
 
     def __getattr__(self, attr):
         if attr in self.meters:

--- a/utils.py
+++ b/utils.py
@@ -323,7 +323,8 @@ class MetricLogger(object):
                 v = v.item()
             assert isinstance(v, (float, int))
             self.meters[k].update(v)
-        wandb.log(self.meters)
+            if self.use_wandb:
+                wandb.log({k:v})
 
     def __getattr__(self, attr):
         if attr in self.meters:

--- a/utils.py
+++ b/utils.py
@@ -312,10 +312,12 @@ def reduce_dict(input_dict, average=True):
 
 
 class MetricLogger(object):
-    def __init__(self, delimiter="\t", use_wandb = True):
+    def __init__(self, args, delimiter="\t"):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
-        self.use_wandb = use_wandb
+        self.use_wandb = args.use_wandb
+        if is_main_process() and self.use_wandb:
+                self.wandb_run = wandb.init(project=args.wandb_project, entity=args.wandb_entity, config=args)
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -323,7 +325,7 @@ class MetricLogger(object):
                 v = v.item()
             assert isinstance(v, (float, int))
             self.meters[k].update(v)
-            if self.use_wandb:
+            if is_main_process() and self.wandb_run:
                 wandb.log({k:v})
 
     def __getattr__(self, attr):

--- a/utils.py
+++ b/utils.py
@@ -28,11 +28,16 @@ from collections import defaultdict, deque
 
 import numpy as np
 import torch
-import wandb
 from torch import nn
 import torch.distributed as dist
 from PIL import ImageFilter, ImageOps
 
+try:
+    import wandb
+
+    assert hasattr(wandb, '__version__')  # verify package import not local dir
+except (ImportError, AssertionError):
+    wandb = None
 
 class GaussianBlur(object):
     """


### PR DESCRIPTION
This PR aims to add basic [**Weights and Biases**](https://wandb.ai/site) Metric Logging by appending to the existing `MetricLogger` Class defined in [**`utils.py`**](https://github.com/facebookresearch/dino/blob/main/utils.py) with minimal changes while supporting Multiple GPU logging with torch distributed. 

The changes can be summarized as follows :-

1. Pass the `args` to the `MetricLogger` which if the `--use_wandb` is set to `True`, creates and run and logs metrics using the `update` function.
2. Add 3 extra arguments namely `--use_wandb`, `--wandb_project` and `--wandb_entity` which can be used to specify whether to use wandb, the name of the project to be used (`"dino"` by default) and name of the entity to be used.

---

Here are some graphs and runs that were logged using this logger.

| Image        | Description    |
|--------------|-----------|
| ![DINO-Loss](https://user-images.githubusercontent.com/61241031/143876848-0a2a1c77-83eb-408d-bb3e-1ba99d3791d6.png) | A W&B Panel showcasing the loss as logged by `metric_logger.update(loss=loss.item())`  |
| <img width="659" alt="Screenshot 2021-11-29 at 6 59 18 PM" src="https://user-images.githubusercontent.com/61241031/143877112-8fb3f887-cade-4dbe-a0dc-921aa7e342dd.png"> | The corresponding wandb config containing all parameters provided using `argparse`, logged using `self.wandb_run = wandb.init(..., config=args)` |


