### PR TITLE
Remove redundant rescaling in feature extraction

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -824,6 +824,5 @@ def multi_scale(samples, model):
             v = feats
         else:
             v += feats
-    v /= 3
     v /= v.norm()
     return v


### PR DESCRIPTION
Hi guys and thank you for your amazing code, 

I noticed that you are scaling the feature vector before normalizing it which is equivalent to simply normalize it.