### PR TITLE
Make vision transformer use its classifier head

### DIFF
--- a/vision_transformer.py
+++ b/vision_transformer.py
@@ -211,6 +211,7 @@ class VisionTransformer(nn.Module):
         for blk in self.blocks:
             x = blk(x)
         x = self.norm(x)
+        x = self.head(x)
         return x[:, 0]
 
     def get_last_selfattention(self, x):


### PR DESCRIPTION
As I was using the model for my own thesis, I came to realizing, that the `num_classes` parameter in the `VisionTransformer` class of the `vision_transformer.py` doesn't seem to do anything. 

I found that kind of strange, as I recalled seeing the classifying layer in the code.
It seems, the `self.head` property is simply not called in the `forward` pass.

The fix is a simple one-liner to activate the code that is already in place and has no implications on the function of the rest of the repository, as
- the transformer always gets used with `num_classes=0` as far as I can tell
- the `self.head` gets set to a `nn.Identity()` in case `num_classes=0`

This is just to fix the model for the people, that expect this parameter to do something.

fixes #201