### PR TITLE
Prefix python modules

### DIFF
--- a/dino/eval_copy_detection.py
+++ b/dino/eval_copy_detection.py
@@ -25,9 +25,9 @@ from torchvision import transforms as pth_transforms
 from PIL import Image, ImageFile
 import numpy as np
 
-import utils
-import vision_transformer as vits
-from eval_knn import extract_features
+import dino.utils
+import dino.vision_transformer as vits
+from dino.eval_knn import extract_features
 
 
 class CopydaysDataset():
@@ -161,7 +161,7 @@ def extract_features(image_list, model, args):
         num_workers=args.num_workers, drop_last=False,
         sampler=torch.utils.data.DistributedSampler(tempdataset, shuffle=False))
     features = None
-    for samples, index in utils.MetricLogger(delimiter="  ").log_every(data_loader, 10):
+    for samples, index in dino.utils.MetricLogger(delimiter="  ").log_every(data_loader, 10):
         samples, index = samples.cuda(non_blocking=True), index.cuda(non_blocking=True)
         feats = model.get_intermediate_layers(samples, n=1)[0].clone()
 
@@ -215,7 +215,7 @@ if __name__ == '__main__':
     parser.add_argument('--imsize', default=320, type=int, help='Image size (square image)')
     parser.add_argument('--batch_size_per_gpu', default=16, type=int, help='Per-GPU batch-size')
     parser.add_argument('--pretrained_weights', default='', type=str, help="Path to pretrained weights to evaluate.")
-    parser.add_argument('--use_cuda', default=True, type=utils.bool_flag)
+    parser.add_argument('--use_cuda', default=True, type=dino.utils.bool_flag)
     parser.add_argument('--arch', default='vit_base', type=str, help='Architecture')
     parser.add_argument('--patch_size', default=8, type=int, help='Patch resolution of the model.')
     parser.add_argument("--checkpoint_key", default="teacher", type=str,
@@ -226,8 +226,8 @@ if __name__ == '__main__':
     parser.add_argument("--local_rank", default=0, type=int, help="Please ignore and do not set this argument.")
     args = parser.parse_args()
 
-    utils.init_distributed_mode(args)
-    print("git:\n  {}\n".format(utils.get_sha()))
+    dino.utils.init_distributed_mode(args)
+    print("git:\n  {}\n".format(dino.utils.get_sha()))
     print("\n".join("%s: %s" % (k, str(v)) for k, v in sorted(dict(vars(args)).items())))
     cudnn.benchmark = True
 
@@ -241,7 +241,7 @@ if __name__ == '__main__':
     if args.use_cuda:
         model.cuda()
     model.eval()
-    utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
+    dino.utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
 
     dataset = CopydaysDataset(args.data_path)
 
@@ -250,7 +250,7 @@ if __name__ == '__main__':
     queries = []
     for q in dataset.query_blocks:
         queries.append(extract_features(dataset.get_block(q), model, args))
-    if utils.get_rank() == 0:
+    if dino.utils.get_rank() == 0:
         queries = torch.cat(queries)
         print(f"Extraction of queries features done. Shape: {queries.shape}")
 
@@ -264,7 +264,7 @@ if __name__ == '__main__':
         print("Using distractors...")
         list_distractors = [os.path.join(args.distractors_path, s) for s in os.listdir(args.distractors_path) if is_image_file(s)]
         database.append(extract_features(list_distractors, model, args))
-    if utils.get_rank() == 0:
+    if dino.utils.get_rank() == 0:
         database = torch.cat(database)
         print(f"Extraction of database and distractors features done. Shape: {database.shape}")
 
@@ -273,12 +273,12 @@ if __name__ == '__main__':
         print(f"Extracting features on images from {args.whitening_path} for learning the whitening operator.")
         list_whit = [os.path.join(args.whitening_path, s) for s in os.listdir(args.whitening_path) if is_image_file(s)]
         features_for_whitening = extract_features(list_whit, model, args)
-        if utils.get_rank() == 0:
+        if dino.utils.get_rank() == 0:
             # center
             mean_feature = torch.mean(features_for_whitening, dim=0)
             database -= mean_feature
             queries -= mean_feature
-            pca = utils.PCA(dim=database.shape[-1], whit=0.5)
+            pca = dino.utils.PCA(dim=database.shape[-1], whit=0.5)
             # compute covariance
             cov = torch.mm(features_for_whitening.T, features_for_whitening) / features_for_whitening.shape[0]
             pca.train_pca(cov.cpu().numpy())
@@ -286,7 +286,7 @@ if __name__ == '__main__':
             queries = pca.apply(queries)
 
     # ============ Copy detection ... ============
-    if utils.get_rank() == 0:
+    if dino.utils.get_rank() == 0:
         # l2 normalize the features
         database = nn.functional.normalize(database, dim=1, p=2)
         queries = nn.functional.normalize(queries, dim=1, p=2)

--- a/dino/eval_knn.py
+++ b/dino/eval_knn.py
@@ -23,8 +23,8 @@ from torchvision import datasets
 from torchvision import transforms as pth_transforms
 from torchvision import models as torchvision_models
 
-import utils
-import vision_transformer as vits
+import dino.utils
+import dino.vision_transformer as vits
 
 
 def extract_feature_pipeline(args):
@@ -68,7 +68,7 @@ def extract_feature_pipeline(args):
         print(f"Architecture {args.arch} non supported")
         sys.exit(1)
     model.cuda()
-    utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
+    dino.utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
     model.eval()
 
     # ============ extract features ... ============
@@ -77,7 +77,7 @@ def extract_feature_pipeline(args):
     print("Extracting features for val set...")
     test_features = extract_features(model, data_loader_val, args.use_cuda)
 
-    if utils.get_rank() == 0:
+    if dino.utils.get_rank() == 0:
         train_features = nn.functional.normalize(train_features, dim=1, p=2)
         test_features = nn.functional.normalize(test_features, dim=1, p=2)
 
@@ -94,13 +94,13 @@ def extract_feature_pipeline(args):
 
 @torch.no_grad()
 def extract_features(model, data_loader, use_cuda=True, multiscale=False):
-    metric_logger = utils.MetricLogger(delimiter="  ")
+    metric_logger = dino.utils.MetricLogger(delimiter="  ")
     features = None
     for samples, index in metric_logger.log_every(data_loader, 10):
         samples = samples.cuda(non_blocking=True)
         index = index.cuda(non_blocking=True)
         if multiscale:
-            feats = utils.multi_scale(samples, model)
+            feats = dino.utils.multi_scale(samples, model)
         else:
             feats = model(samples).clone()
 
@@ -196,7 +196,7 @@ if __name__ == '__main__':
     parser.add_argument('--temperature', default=0.07, type=float,
         help='Temperature used in the voting coefficient')
     parser.add_argument('--pretrained_weights', default='', type=str, help="Path to pretrained weights to evaluate.")
-    parser.add_argument('--use_cuda', default=True, type=utils.bool_flag,
+    parser.add_argument('--use_cuda', default=True, type=dino.utils.bool_flag,
         help="Should we store the features on GPU? We recommend setting this to False if you encounter OOM")
     parser.add_argument('--arch', default='vit_small', type=str, help='Architecture')
     parser.add_argument('--patch_size', default=16, type=int, help='Patch resolution of the model.')
@@ -213,8 +213,8 @@ if __name__ == '__main__':
     parser.add_argument('--data_path', default='/path/to/imagenet/', type=str)
     args = parser.parse_args()
 
-    utils.init_distributed_mode(args)
-    print("git:\n  {}\n".format(utils.get_sha()))
+    dino.utils.init_distributed_mode(args)
+    print("git:\n  {}\n".format(dino.utils.get_sha()))
     print("\n".join("%s: %s" % (k, str(v)) for k, v in sorted(dict(vars(args)).items())))
     cudnn.benchmark = True
 
@@ -227,7 +227,7 @@ if __name__ == '__main__':
         # need to extract features !
         train_features, test_features, train_labels, test_labels = extract_feature_pipeline(args)
 
-    if utils.get_rank() == 0:
+    if dino.utils.get_rank() == 0:
         if args.use_cuda:
             train_features = train_features.cuda()
             test_features = test_features.cuda()

--- a/dino/eval_linear.py
+++ b/dino/eval_linear.py
@@ -24,13 +24,13 @@ from torchvision import datasets
 from torchvision import transforms as pth_transforms
 from torchvision import models as torchvision_models
 
-import utils
-import vision_transformer as vits
+import dino.utils
+import dino.vision_transformer as vits
 
 
 def eval_linear(args):
-    utils.init_distributed_mode(args)
-    print("git:\n  {}\n".format(utils.get_sha()))
+    dino.utils.init_distributed_mode(args)
+    print("git:\n  {}\n".format(dino.utils.get_sha()))
     print("\n".join("%s: %s" % (k, str(v)) for k, v in sorted(dict(vars(args)).items())))
     cudnn.benchmark = True
 
@@ -54,7 +54,7 @@ def eval_linear(args):
     model.cuda()
     model.eval()
     # load weights to evaluate
-    utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
+    dino.utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
     print(f"Model {args.arch} built.")
 
     linear_classifier = LinearClassifier(embed_dim, num_labels=args.num_labels)
@@ -77,7 +77,7 @@ def eval_linear(args):
     )
 
     if args.evaluate:
-        utils.load_pretrained_linear_weights(linear_classifier, args.arch, args.patch_size)
+        dino.utils.load_pretrained_linear_weights(linear_classifier, args.arch, args.patch_size)
         test_stats = validate_network(val_loader, model, linear_classifier, args.n_last_blocks, args.avgpool_patchtokens)
         print(f"Accuracy of the network on the {len(dataset_val)} test images: {test_stats['acc1']:.1f}%")
         return
@@ -102,7 +102,7 @@ def eval_linear(args):
     # set optimizer
     optimizer = torch.optim.SGD(
         linear_classifier.parameters(),
-        args.lr * (args.batch_size_per_gpu * utils.get_world_size()) / 256., # linear scaling rule
+        args.lr * (args.batch_size_per_gpu * dino.utils.get_world_size()) / 256., # linear scaling rule
         momentum=0.9,
         weight_decay=0, # we do not apply weight decay
     )
@@ -110,7 +110,7 @@ def eval_linear(args):
 
     # Optionally resume from a checkpoint
     to_restore = {"epoch": 0, "best_acc": 0.}
-    utils.restart_from_checkpoint(
+    dino.utils.restart_from_checkpoint(
         os.path.join(args.output_dir, "checkpoint.pth.tar"),
         run_variables=to_restore,
         state_dict=linear_classifier,
@@ -135,7 +135,7 @@ def eval_linear(args):
             print(f'Max accuracy so far: {best_acc:.2f}%')
             log_stats = {**{k: v for k, v in log_stats.items()},
                          **{f'test_{k}': v for k, v in test_stats.items()}}
-        if utils.is_main_process():
+        if dino.utils.is_main_process():
             with (Path(args.output_dir) / "log.txt").open("a") as f:
                 f.write(json.dumps(log_stats) + "\n")
             save_dict = {
@@ -152,8 +152,8 @@ def eval_linear(args):
 
 def train(model, linear_classifier, optimizer, loader, epoch, n, avgpool):
     linear_classifier.train()
-    metric_logger = utils.MetricLogger(delimiter="  ")
-    metric_logger.add_meter('lr', utils.SmoothedValue(window_size=1, fmt='{value:.6f}'))
+    metric_logger = dino.utils.MetricLogger(delimiter="  ")
+    metric_logger.add_meter('lr', dino.utils.SmoothedValue(window_size=1, fmt='{value:.6f}'))
     header = 'Epoch: [{}]'.format(epoch)
     for (inp, target) in metric_logger.log_every(loader, 20, header):
         # move to gpu
@@ -195,7 +195,7 @@ def train(model, linear_classifier, optimizer, loader, epoch, n, avgpool):
 @torch.no_grad()
 def validate_network(val_loader, model, linear_classifier, n, avgpool):
     linear_classifier.eval()
-    metric_logger = utils.MetricLogger(delimiter="  ")
+    metric_logger = dino.utils.MetricLogger(delimiter="  ")
     header = 'Test:'
     for inp, target in metric_logger.log_every(val_loader, 20, header):
         # move to gpu
@@ -216,9 +216,9 @@ def validate_network(val_loader, model, linear_classifier, n, avgpool):
         loss = nn.CrossEntropyLoss()(output, target)
 
         if linear_classifier.module.num_labels >= 5:
-            acc1, acc5 = utils.accuracy(output, target, topk=(1, 5))
+            acc1, acc5 = dino.utils.accuracy(output, target, topk=(1, 5))
         else:
-            acc1, = utils.accuracy(output, target, topk=(1,))
+            acc1, = dino.utils.accuracy(output, target, topk=(1,))
 
         batch_size = inp.shape[0]
         metric_logger.update(loss=loss.item())
@@ -255,7 +255,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser('Evaluation with linear classification on ImageNet')
     parser.add_argument('--n_last_blocks', default=4, type=int, help="""Concatenate [CLS] tokens
         for the `n` last blocks. We use `n=4` when evaluating ViT-Small and `n=1` with ViT-Base.""")
-    parser.add_argument('--avgpool_patchtokens', default=False, type=utils.bool_flag,
+    parser.add_argument('--avgpool_patchtokens', default=False, type=dino.utils.bool_flag,
         help="""Whether ot not to concatenate the global average pooled features to the [CLS] token.
         We typically set this to False for ViT-Small and to True with ViT-Base.""")
     parser.add_argument('--arch', default='vit_small', type=str, help='Architecture')

--- a/dino/eval_video_segmentation.py
+++ b/dino/eval_video_segmentation.py
@@ -30,8 +30,8 @@ from torch.nn import functional as F
 from PIL import Image
 from torchvision import transforms
 
-import utils
-import vision_transformer as vits
+import dino.utils
+import dino.vision_transformer as vits
 
 
 @torch.no_grad()
@@ -264,14 +264,14 @@ if __name__ == '__main__':
     parser.add_argument("--bs", type=int, default=6, help="Batch size, try to reduce if OOM")
     args = parser.parse_args()
 
-    print("git:\n  {}\n".format(utils.get_sha()))
+    print("git:\n  {}\n".format(dino.utils.get_sha()))
     print("\n".join("%s: %s" % (k, str(v)) for k, v in sorted(dict(vars(args)).items())))
 
     # building network
     model = vits.__dict__[args.arch](patch_size=args.patch_size, num_classes=0)
     print(f"Model {args.arch} {args.patch_size}x{args.patch_size} built.")
     model.cuda()
-    utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
+    dino.utils.load_pretrained_weights(model, args.pretrained_weights, args.checkpoint_key, args.arch, args.patch_size)
     for param in model.parameters():
         param.requires_grad = False
     model.eval()

--- a/dino/hubconf.py
+++ b/dino/hubconf.py
@@ -14,7 +14,7 @@
 import torch
 from torchvision.models.resnet import resnet50
 
-import vision_transformer as vits
+import dino.vision_transformer as vits
 
 dependencies = ["torch", "torchvision"]
 

--- a/dino/run_with_submitit.py
+++ b/dino/run_with_submitit.py
@@ -20,12 +20,12 @@ import os
 import uuid
 from pathlib import Path
 
-import main_dino
+import dino.main_dino
 import submitit
 
 
 def parse_args():
-    parser = argparse.ArgumentParser("Submitit for DINO", parents=[main_dino.get_args_parser()])
+    parser = argparse.ArgumentParser("Submitit for DINO", parents=[dino.main_dino.get_args_parser()])
     parser.add_argument("--ngpus", default=8, type=int, help="Number of gpus to request on each node")
     parser.add_argument("--nodes", default=2, type=int, help="Number of nodes to request")
     parser.add_argument("--timeout", default=2800, type=int, help="Duration of the job")
@@ -60,10 +60,10 @@ class Trainer(object):
         self.args = args
 
     def __call__(self):
-        import main_dino
+        import dino.main_dino
 
         self._setup_gpu_args()
-        main_dino.train_dino(self.args)
+        dino.main_dino.train_dino(self.args)
 
     def checkpoint(self):
         import os

--- a/dino/utils.py
+++ b/dino/utils.py
@@ -103,6 +103,7 @@ def load_pretrained_weights(model, pretrained_weights, checkpoint_key, model_nam
             url = "dino_resnet50_pretrain/dino_resnet50_pretrain.pth"
         if url is not None:
             print("Since no pretrained weights have been provided, we load the reference pretrained DINO weights.")
+            print(f"Going to download {url=} via torch.hub")
             state_dict = torch.hub.load_state_dict_from_url(url="https://dl.fbaipublicfiles.com/dino/" + url)
             model.load_state_dict(state_dict, strict=True)
         else:
@@ -123,6 +124,7 @@ def load_pretrained_linear_weights(linear_classifier, model_name, patch_size):
         url = "dino_resnet50_pretrain/dino_resnet50_linearweights.pth"
     if url is not None:
         print("We load the reference pretrained linear weights.")
+        print(f"Going to download {url=} via torch.hub")
         state_dict = torch.hub.load_state_dict_from_url(url="https://dl.fbaipublicfiles.com/dino/" + url)["state_dict"]
         linear_classifier.load_state_dict(state_dict, strict=True)
     else:

--- a/dino/video_generation.py
+++ b/dino/video_generation.py
@@ -26,8 +26,8 @@ from torchvision import transforms as pth_transforms
 import numpy as np
 from PIL import Image
 
-import utils
-import vision_transformer as vits
+import dino.utils
+import dino.vision_transformer as vits
 
 
 FOURCC = {

--- a/dino/vision_transformer.py
+++ b/dino/vision_transformer.py
@@ -21,7 +21,7 @@ from functools import partial
 import torch
 import torch.nn as nn
 
-from utils import trunc_normal_
+from dino.utils import trunc_normal_
 
 
 def drop_path(x, drop_prob: float = 0., training: bool = False):

--- a/dino/visualize_attention.py
+++ b/dino/visualize_attention.py
@@ -31,8 +31,8 @@ from torchvision import transforms as pth_transforms
 import numpy as np
 from PIL import Image
 
-import utils
-import vision_transformer as vits
+import dino.utils
+import dino.vision_transformer as vits
 
 
 def apply_mask(image, mask, color, alpha=0.5):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [ "setuptools" ]
+
+[project]
+name = "dino"
+version = "2023.04.27"


### PR DESCRIPTION
This is a semi-automated change and relies on the python-rope/rope refactoring library:

```bash
$ nix shell github:SomeoneSerge/pkgs#prefix-python-modules
$ prefix-python-modules . --prefix dino
```

This change extends generic names, like `utils`, with the project project name.
This way `dino` can be used in the same PYTHONPATH with other projects without the risk of collision

The extra commit also adds a `pyproject.toml` file, which is just an easy way to have wheels automatically generated. Wheels make it easier to package `dino` in distributions, including those other than pypi.

The changes have been tested in a somewhat automated way[^1][^2]. Happy to revert or extend any particular bit if you like, just hoping to get the actual prefixes merged. Thanks


[^1]: https://github.com/SomeoneSerge/pkgs/blob/0d2b35d8704636ffb6538c24b4e5c180d9bb17a3/python-packages/by-name/om/omnimotion/preprocess-dataset.nix#L14-L18
[^2]: https://github.com/SomeoneSerge/pkgs/blob/0d2b35d8704636ffb6538c24b4e5c180d9bb17a3/python-packages/by-name/di/dino/package.nix#L29