### PR TITLE
fixed default warmup teacher temp epochs

### DIFF
--- a/main_dino.py
+++ b/main_dino.py
@@ -71,7 +71,7 @@ def get_args_parser():
     parser.add_argument('--teacher_temp', default=0.04, type=float, help="""Final value (after linear warmup)
         of the teacher temperature. For most experiments, anything above 0.07 is unstable. We recommend
         starting with the default value of 0.04 and increase this slightly if needed.""")
-    parser.add_argument('--warmup_teacher_temp_epochs', default=0, type=int,
+    parser.add_argument('--warmup_teacher_temp_epochs', default=30, type=int,
         help='Number of warmup epochs for the teacher temperature (Default: 30).')
 
     # Training/Optimization parameters


### PR DESCRIPTION
In the helper string, it is said that the warmup teacher temp epochs should be 30, but the default value is set to 0.